### PR TITLE
Add Perl6::Parser to depends

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,8 @@
   ],
   "build-depends" : [ ],
   "depends" : [
-    "Test::META"
+    "Test::META",
+    "Perl6::Parser"
   ],
   "description" : "Perl 6 tidier",
   "license" : "Artistic-2.0",


### PR DESCRIPTION
Currently fails to install if Perl6::Parser is not already installed.